### PR TITLE
added --production option to shards install

### DIFF
--- a/lib/capistrano/kemal/tasks/kemal.rake
+++ b/lib/capistrano/kemal/tasks/kemal.rake
@@ -1,7 +1,7 @@
 namespace :load do
   task :defaults do
     set :kemal_pid, -> { File.join(shared_path, "kemal.pid") }
-    set :kemal_file, 'app.cr'
+    set :kemal_file, 'src/app.cr'
     set :kemal_env, 'development'
     set :kemal_log_file, 'kemal.log'
   end
@@ -11,7 +11,7 @@ namespace :deploy do
   after :updated, :build do
     on roles(:web) do
       execute "cd '#{release_path}' && shards install --production"
-      execute "cd '#{release_path}' && crystal build --release src/#{fetch(:kemal_file)}"
+      execute "cd '#{release_path}' && crystal build --release #{fetch(:kemal_file)}"
     end
   end
 end

--- a/lib/capistrano/kemal/tasks/kemal.rake
+++ b/lib/capistrano/kemal/tasks/kemal.rake
@@ -10,7 +10,7 @@ end
 namespace :deploy do
   after :updated, :build do
     on roles(:web) do
-      execute "cd '#{release_path}' && shards install"
+      execute "cd '#{release_path}' && shards install --production"
       execute "cd '#{release_path}' && crystal build --release src/#{fetch(:kemal_file)}"
     end
   end


### PR DESCRIPTION
When deploying we should ignore all development dependencies.